### PR TITLE
Add Windows ARM64 build to SDSIO server workflow

### DIFF
--- a/.github/workflows/build_sdsio-server.yml
+++ b/.github/workflows/build_sdsio-server.yml
@@ -27,10 +27,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2025, ubuntu-24.04, macos-15, ubuntu-24.04-arm]
+        os: [windows-2025, windows-11-arm, ubuntu-24.04, macos-15, ubuntu-24.04-arm]
         include:
           - os: windows-2025
             artifact_name: sdsio-server-windows
+          - os: windows-11-arm
+            artifact_name: sdsio-server-windows-arm64
           - os: ubuntu-24.04
             artifact_name: sdsio-server-linux
           - os: macos-15


### PR DESCRIPTION
## Summary
- Add `windows-11-arm` to the SDSIO server build matrix.
- Publish the resulting artifact as `sdsio-server-windows-arm64`.

## Rationale
Enable CI coverage and artifact generation for Windows ARM64.

## Risks / Follow-up
- The workflow now depends on availability and compatibility of the Windows ARM runner.
- Windows ARM64 build issues may require follow-up changes to dependencies or build configuration.